### PR TITLE
Adds ability to edit an existing term via TermController

### DIFF
--- a/SchoolPlanner.Api/Controllers/TermController.cs
+++ b/SchoolPlanner.Api/Controllers/TermController.cs
@@ -44,5 +44,19 @@ namespace SchoolPlanner.Api.Controllers
             }
 
         }
+
+        [HttpPut(Name = "UpdateTerm")]
+        public async Task<ActionResult<Term>> Put([FromBody]Term updatedTerm)
+        {
+            try
+            {
+                var updated = await _termRepository.UpdateExistingTermAsync(updatedTerm);
+                return Ok(updated);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, ex.Message);
+            }
+        }
     }
 }

--- a/SchoolPlanner.Api/Program.cs
+++ b/SchoolPlanner.Api/Program.cs
@@ -25,9 +25,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-#if !DEBUG
-//app.UseHttpsRedirection();
-#endif
+app.UseHttpsRedirection();
 
 app.UseRouting();
 

--- a/SchoolPlanner.Data/Interfaces/ITermRepository.cs
+++ b/SchoolPlanner.Data/Interfaces/ITermRepository.cs
@@ -8,5 +8,6 @@ namespace SchoolPlanner.Data.Interfaces
     {
         Task<IEnumerable<Term>> GetAllTermsAsync();
         Task<Term> AddNewTermAsync(Term newTerm);
+        Task<Term> UpdateExistingTermAsync(Term updatedTerm); 
     }
 }

--- a/SchoolPlanner.Data/Repositories/TermRepository.cs
+++ b/SchoolPlanner.Data/Repositories/TermRepository.cs
@@ -25,5 +25,13 @@ namespace SchoolPlanner.Data.Repositories
 
             return newTerm; 
         }
+
+        public async Task<Term> UpdateExistingTermAsync(Term updatedTerm)
+        {
+            _dbContext.Terms.Update(updatedTerm);
+            await _dbContext.SaveChangesAsync();
+
+            return updatedTerm;
+        }
     }
 }

--- a/SchoolPlanner.Data/SchoolDBContext.cs
+++ b/SchoolPlanner.Data/SchoolDBContext.cs
@@ -14,5 +14,27 @@ namespace SchoolPlanner.Data
 
         public DbSet<Term> Terms { get; set; }
 
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Term>().Property<DateTime>("UpdatedOn"); 
+        }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            SetTimeStamps(); 
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+
+
+        private void SetTimeStamps()
+        {
+            var entries = ChangeTracker.Entries()
+                .Where(e => e.Entity is Term && (e.State == EntityState.Modified));
+
+            foreach (var entry in entries)
+            {
+                entry.Property("UpdatedOn").CurrentValue = DateTime.UtcNow;
+            }
+        }
     }
 }


### PR DESCRIPTION
First:
This adds the simple method 'UpdateExistingTermAsync` to the TermRepo. That method takes a term object and simply updates that existing term in the DB. Then returns that updated term. 

Second: 
The `TermController` calls that new method via it's new `PUT` method. Which takes a term object from the body of the request. 

Third: 
I updated the DBContext in the DB project to now update the `UpdatedOn` column on the Term table with the current date in utc. This is done via a shadow property since I don't have that property on the Term model at the application layer. This allows us to update the column without the use of a table trigger now. 